### PR TITLE
Package.json trivial issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,11 @@
     "grunt-contrib-requirejs" : "~0.4.0",
     "grunt-contrib-watch": "~0.2.0",
     "grunt-contrib-connect": "~0.2.0"
-  }
+  },
+  "licenses": [
+    {
+      "type": "Apache License, Version 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "camunda-bpmn.js",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/camunda/camunda-bpmn.js"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-requirejs" : "~0.4.0",


### PR DESCRIPTION
It would be useful to add `bugs` too, to let people know if the preferred tracker is the product related one or issues here in github, e.g.:

```
$ git diff
diff --git a/package.json b/package.json
index 671d802..6c6f4e9 100644
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/camunda/camunda-bpmn.js"
   },
+  "bugs": "https://app.camunda.com/jira/browse/CAM/component/11950",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-requirejs" : "~0.4.0",

```
